### PR TITLE
Generalize language model service

### DIFF
--- a/data/src/main/java/com/arova/data/FoodRepositoryImpl.kt
+++ b/data/src/main/java/com/arova/data/FoodRepositoryImpl.kt
@@ -2,14 +2,15 @@ package com.arova.data
 
 import com.arova.domain.FoodItem
 import com.arova.domain.FoodRepository
+import com.arova.data.LanguageModelApiService
 import javax.inject.Inject
 
 class FoodRepositoryImpl @Inject constructor(
-    private val geminiApi: GeminiApiService,
+    private val languageModelApi: LanguageModelApiService,
     private val foodDatabaseApi: FoodDatabaseApiService
 ) : FoodRepository {
     override suspend fun parseFood(query: String): List<FoodItem> {
-        val names = geminiApi.parseNaturalLanguage(query)
+        val names = languageModelApi.parseNaturalLanguage(query)
         return names.map { name ->
             foodDatabaseApi.getNutritionInfo(name, 1.0, "unit")
         }

--- a/data/src/main/java/com/arova/data/GeminiApiService.kt
+++ b/data/src/main/java/com/arova/data/GeminiApiService.kt
@@ -1,5 +1,0 @@
-package com.arova.data
-
-interface GeminiApiService {
-    suspend fun parseNaturalLanguage(query: String): List<String>
-}

--- a/data/src/main/java/com/arova/data/LanguageModelApiService.kt
+++ b/data/src/main/java/com/arova/data/LanguageModelApiService.kt
@@ -1,0 +1,10 @@
+package com.arova.data
+
+/**
+ * Generic interface for parsing natural language meal descriptions using any
+ * language model provider. Implementations can delegate to services such as
+ * Gemini or OpenAI.
+ */
+interface LanguageModelApiService {
+    suspend fun parseNaturalLanguage(query: String): List<String>
+}

--- a/data/src/main/java/com/arova/data/di/DataModule.kt
+++ b/data/src/main/java/com/arova/data/di/DataModule.kt
@@ -68,7 +68,7 @@ interface DataModule {
 
         @Provides
         @Singleton
-        fun provideGeminiApiService(service: GeminiService): GeminiApiService =
+        fun provideLanguageModelApiService(service: GeminiService): LanguageModelApiService =
             GeminiApiServiceImpl(service)
 
         @Provides

--- a/data/src/main/java/com/arova/data/remote/GeminiApiServiceImpl.kt
+++ b/data/src/main/java/com/arova/data/remote/GeminiApiServiceImpl.kt
@@ -1,11 +1,11 @@
 package com.arova.data.remote
 
-import com.arova.data.GeminiApiService
+import com.arova.data.LanguageModelApiService
 import javax.inject.Inject
 
 class GeminiApiServiceImpl @Inject constructor(
     private val service: GeminiService
-) : GeminiApiService {
+) : LanguageModelApiService {
     override suspend fun parseNaturalLanguage(query: String): List<String> {
         return service.parse(GeminiRequest(query)).items
     }


### PR DESCRIPTION
## Summary
- replace `GeminiApiService` with generic `LanguageModelApiService`
- inject the generic service into `FoodRepositoryImpl`
- update DI module and Gemini implementation

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687268019930832b88007a879bf10135