### PR TITLE
Implement Navigation with basic screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.material.icons.extended)
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)

--- a/app/src/main/java/com/arova/arova/MainActivity.kt
+++ b/app/src/main/java/com/arova/arova/MainActivity.kt
@@ -4,16 +4,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.arova.arova.ui.navigation.AppNavGraph
 import com.arova.arova.ui.theme.ArovaTheme
-import com.arova.arova.meallogging.MealViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -21,44 +13,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ArovaTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    MealScreen(Modifier.padding(innerPadding))
-                }
+                AppNavGraph()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Composable
-fun MealScreen(modifier: Modifier = Modifier, viewModel: MealViewModel = hiltViewModel()) {
-    val items by viewModel.items.collectAsState()
-    var text by remember { mutableStateOf("") }
-    Column(modifier.fillMaxSize().padding(16.dp)) {
-        OutlinedTextField(value = text, onValueChange = { text = it }, label = { Text("Meal") })
-        Spacer(Modifier.height(8.dp))
-        Button(onClick = { viewModel.onLogMealClicked(text) }) {
-            Text("Parse")
-        }
-        LazyColumn {
-            items(items) { item ->
-                Text(item.name)
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    ArovaTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/arova/arova/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/dashboard/DashboardScreen.kt
@@ -1,0 +1,10 @@
+package com.arova.arova.ui.dashboard
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun DashboardScreen(viewModel: DashboardViewModel = hiltViewModel()) {
+    Text(text = "Dashboard")
+}

--- a/app/src/main/java/com/arova/arova/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/dashboard/DashboardViewModel.kt
@@ -1,0 +1,8 @@
+package com.arova.arova.ui.dashboard
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class DashboardViewModel @Inject constructor() : ViewModel()

--- a/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingScreen.kt
@@ -1,0 +1,10 @@
+package com.arova.arova.ui.foodlogging
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun FoodLoggingScreen(viewModel: FoodLoggingViewModel = hiltViewModel()) {
+    Text(text = "Food Logging")
+}

--- a/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingViewModel.kt
@@ -1,0 +1,8 @@
+package com.arova.arova.ui.foodlogging
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class FoodLoggingViewModel @Inject constructor() : ViewModel()

--- a/app/src/main/java/com/arova/arova/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/arova/arova/ui/navigation/AppNavGraph.kt
@@ -1,0 +1,59 @@
+package com.arova.arova.ui.navigation
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.arova.arova.ui.dashboard.DashboardScreen
+import com.arova.arova.ui.foodlogging.FoodLoggingScreen
+import com.arova.arova.ui.signup.SignUpScreen
+import com.arova.arova.ui.welcome.WelcomeScreen
+
+@Composable
+fun AppNavGraph() {
+    val navController = rememberNavController()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
+
+    androidx.compose.material3.Scaffold(
+        bottomBar = {
+            NavigationBar {
+                BottomNavItem.items.forEach { item ->
+                    NavigationBarItem(
+                        selected = currentRoute == item.route,
+                        onClick = {
+                            navController.navigate(item.route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        icon = { Icon(item.icon, contentDescription = item.label) },
+                        label = { Text(item.label) }
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = BottomNavItem.Welcome.route,
+            modifier = androidx.compose.ui.Modifier.padding(innerPadding)
+        ) {
+            composable(BottomNavItem.Welcome.route) { WelcomeScreen() }
+            composable(BottomNavItem.SignUp.route) { SignUpScreen() }
+            composable(BottomNavItem.Dashboard.route) { DashboardScreen() }
+            composable(BottomNavItem.FoodLogging.route) { FoodLoggingScreen() }
+        }
+    }
+}

--- a/app/src/main/java/com/arova/arova/ui/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/arova/arova/ui/navigation/BottomNavItem.kt
@@ -1,0 +1,19 @@
+package com.arova.arova.ui.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class BottomNavItem(val route: String, val icon: ImageVector, val label: String) {
+    object Welcome : BottomNavItem("welcome", Icons.Filled.Star, "Welcome")
+    object SignUp : BottomNavItem("signup", Icons.Filled.Person, "Sign Up")
+    object Dashboard : BottomNavItem("dashboard", Icons.Filled.Home, "Dashboard")
+    object FoodLogging : BottomNavItem("foodlogging", Icons.Filled.List, "Food")
+
+    companion object {
+        val items = listOf(Welcome, SignUp, Dashboard, FoodLogging)
+    }
+}

--- a/app/src/main/java/com/arova/arova/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/signup/SignUpScreen.kt
@@ -1,0 +1,10 @@
+package com.arova.arova.ui.signup
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun SignUpScreen(viewModel: SignUpViewModel = hiltViewModel()) {
+    Text(text = "Sign Up")
+}

--- a/app/src/main/java/com/arova/arova/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/signup/SignUpViewModel.kt
@@ -1,0 +1,8 @@
+package com.arova.arova.ui.signup
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SignUpViewModel @Inject constructor() : ViewModel()

--- a/app/src/main/java/com/arova/arova/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/welcome/WelcomeScreen.kt
@@ -1,0 +1,10 @@
+package com.arova.arova.ui.welcome
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun WelcomeScreen(viewModel: WelcomeViewModel = hiltViewModel()) {
+    Text(text = "Welcome")
+}

--- a/app/src/main/java/com/arova/arova/ui/welcome/WelcomeViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/welcome/WelcomeViewModel.kt
@@ -1,0 +1,8 @@
+package com.arova.arova.ui.welcome
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class WelcomeViewModel @Inject constructor() : ViewModel()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ room = "2.6.1"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
 kotlinxSerialization = "1.6.1"
+navigationCompose = "2.7.7"
+materialIconsExtended = "1.6.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,6 +32,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }


### PR DESCRIPTION
## Summary
- add navigation and icon dependencies
- wire up NavGraph with bottom navigation bar
- create simple Welcome, SignUp, Dashboard and FoodLogging screens with ViewModels
- update MainActivity to load the nav graph

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew build --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872691bca24832b9b739d8091c56a27