### PR TITLE
Add basic app flows with sign up and meal logging

### DIFF
--- a/app/src/main/java/com/arova/arova/MainActivity.kt
+++ b/app/src/main/java/com/arova/arova/MainActivity.kt
@@ -6,7 +6,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.arova.arova.ui.navigation.AppNavGraph
 import com.arova.arova.ui.theme.ArovaTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/arova/arova/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/dashboard/DashboardScreen.kt
@@ -1,10 +1,36 @@
 package com.arova.arova.ui.dashboard
 
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
 fun DashboardScreen(viewModel: DashboardViewModel = hiltViewModel()) {
-    Text(text = "Dashboard")
+    val date by viewModel.currentDate.collectAsState()
+    val summary by viewModel.summary.collectAsState()
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+            IconButton(onClick = { viewModel.onPreviousDayClicked() }) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "prev")
+            }
+            Text(text = date.toString(), modifier = Modifier.weight(1f))
+            IconButton(onClick = { viewModel.onNextDayClicked() }) {
+                Icon(Icons.Default.ArrowForward, contentDescription = "next")
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        Text(text = "Calories: ${summary.totalCalories}")
+        Text(text = "Protein: ${summary.protein}")
+        Text(text = "Carbs: ${summary.carbs}")
+        Text(text = "Fat: ${summary.fat}")
+    }
 }

--- a/app/src/main/java/com/arova/arova/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/dashboard/DashboardViewModel.kt
@@ -1,8 +1,42 @@
 package com.arova.arova.ui.dashboard
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.arova.domain.DailySummary
+import com.arova.domain.GetDailySummaryUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
 
 @HiltViewModel
-class DashboardViewModel @Inject constructor() : ViewModel()
+class DashboardViewModel @Inject constructor(
+    private val getDailySummaryUseCase: GetDailySummaryUseCase
+) : ViewModel() {
+
+    private val _currentDate = MutableStateFlow(LocalDate.now())
+    val currentDate: StateFlow<LocalDate> = _currentDate
+
+    private val _summary = MutableStateFlow(DailySummary(0, 0.0, 0.0, 0.0))
+    val summary: StateFlow<DailySummary> = _summary
+
+    init {
+        refresh()
+    }
+
+    private fun refresh() {
+        viewModelScope.launch { _summary.value = getDailySummaryUseCase(_currentDate.value) }
+    }
+
+    fun onPreviousDayClicked() {
+        _currentDate.value = _currentDate.value.minusDays(1)
+        refresh()
+    }
+
+    fun onNextDayClicked() {
+        _currentDate.value = _currentDate.value.plusDays(1)
+        refresh()
+    }
+}

--- a/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingScreen.kt
@@ -1,10 +1,51 @@
 package com.arova.arova.ui.foodlogging
 
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
-fun FoodLoggingScreen(viewModel: FoodLoggingViewModel = hiltViewModel()) {
-    Text(text = "Food Logging")
+fun FoodLoggingScreen(
+    viewModel: FoodLoggingViewModel = hiltViewModel(),
+    onSaved: () -> Unit = {}
+) {
+    val input by viewModel.userInput.collectAsState()
+    val items by viewModel.parsedFoodItems.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.errorMessage.collectAsState()
+
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        viewModel.mealSaved.collect { onSaved() }
+    }
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = input,
+            onValueChange = { viewModel.userInput.value = it },
+            label = { Text("Describe your meal") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { viewModel.onAnalyzeClicked() }) { Text("Analyze") }
+        Spacer(Modifier.height(8.dp))
+        if (isLoading) {
+            CircularProgressIndicator()
+        }
+        items.forEach {
+            Text(text = "${'$'}{it.quantity} ${'$'}{it.unit} ${'$'}{it.name} - ${'$'}{it.calories} cal")
+        }
+        if (items.isNotEmpty()) {
+            Spacer(Modifier.height(8.dp))
+            Button(onClick = { viewModel.onConfirmAndSaveClicked("Meal") }) { Text("Save Meal") }
+        }
+        error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(text = it, color = MaterialTheme.colorScheme.error)
+        }
+    }
 }

--- a/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/foodlogging/FoodLoggingViewModel.kt
@@ -1,8 +1,57 @@
 package com.arova.arova.ui.foodlogging
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.arova.domain.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
-class FoodLoggingViewModel @Inject constructor() : ViewModel()
+class FoodLoggingViewModel @Inject constructor(
+    private val parseMealUseCase: ParseMealUseCase,
+    private val saveMealEntryUseCase: SaveMealEntryUseCase
+) : ViewModel() {
+
+    val userInput = MutableStateFlow("")
+    private val _parsedFoodItems = MutableStateFlow<List<FoodItem>>(emptyList())
+    val parsedFoodItems: StateFlow<List<FoodItem>> = _parsedFoodItems
+
+    val isLoading = MutableStateFlow(false)
+    val errorMessage = MutableStateFlow<String?>(null)
+
+    private val _mealSaved = MutableSharedFlow<Unit>()
+    val mealSaved: SharedFlow<Unit> = _mealSaved
+
+    fun onAnalyzeClicked() {
+        viewModelScope.launch {
+            isLoading.value = true
+            try {
+                _parsedFoodItems.value = parseMealUseCase(userInput.value)
+                errorMessage.value = null
+            } catch (e: Exception) {
+                errorMessage.value = e.message
+            } finally {
+                isLoading.value = false
+            }
+        }
+    }
+
+    fun onConfirmAndSaveClicked(mealType: String) {
+        viewModelScope.launch {
+            try {
+                val meal = MealEntry(_parsedFoodItems.value, java.time.LocalDateTime.now(), mealType)
+                saveMealEntryUseCase(meal)
+                _parsedFoodItems.value = emptyList()
+                userInput.value = ""
+                _mealSaved.emit(Unit)
+            } catch (e: Exception) {
+                errorMessage.value = e.message
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arova/arova/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/arova/arova/ui/navigation/AppNavGraph.kt
@@ -50,10 +50,16 @@ fun AppNavGraph() {
             startDestination = BottomNavItem.Welcome.route,
             modifier = androidx.compose.ui.Modifier.padding(innerPadding)
         ) {
-            composable(BottomNavItem.Welcome.route) { WelcomeScreen() }
-            composable(BottomNavItem.SignUp.route) { SignUpScreen() }
+            composable(BottomNavItem.Welcome.route) {
+                WelcomeScreen(onSignUp = { navController.navigate(BottomNavItem.SignUp.route) })
+            }
+            composable(BottomNavItem.SignUp.route) {
+                SignUpScreen(onSignedUp = { navController.navigate(BottomNavItem.Dashboard.route) })
+            }
             composable(BottomNavItem.Dashboard.route) { DashboardScreen() }
-            composable(BottomNavItem.FoodLogging.route) { FoodLoggingScreen() }
+            composable(BottomNavItem.FoodLogging.route) {
+                FoodLoggingScreen(onSaved = { navController.navigate(BottomNavItem.Dashboard.route) })
+            }
         }
     }
 }

--- a/app/src/main/java/com/arova/arova/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/signup/SignUpScreen.kt
@@ -1,10 +1,63 @@
 package com.arova.arova.ui.signup
 
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
-fun SignUpScreen(viewModel: SignUpViewModel = hiltViewModel()) {
-    Text(text = "Sign Up")
+fun SignUpScreen(
+    viewModel: SignUpViewModel = hiltViewModel(),
+    onSignedUp: () -> Unit = {}
+) {
+    val name by viewModel.name.collectAsState()
+    val email by viewModel.email.collectAsState()
+    val password by viewModel.password.collectAsState()
+    val confirm by viewModel.confirmPassword.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.errorMessage.collectAsState()
+
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        viewModel.signUpSuccess.collect { onSignedUp() }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        OutlinedTextField(value = name, onValueChange = { viewModel.name.value = it }, label = { Text("Name") })
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(value = email, onValueChange = { viewModel.email.value = it }, label = { Text("Email") })
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = password,
+            onValueChange = { viewModel.password.value = it },
+            label = { Text("Password") },
+            visualTransformation = PasswordVisualTransformation()
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = confirm,
+            onValueChange = { viewModel.confirmPassword.value = it },
+            label = { Text("Confirm Password") },
+            visualTransformation = PasswordVisualTransformation()
+        )
+        Spacer(Modifier.height(16.dp))
+        if (isLoading) {
+            CircularProgressIndicator()
+        } else {
+            Button(onClick = { viewModel.onSignUpClicked() }) { Text("Sign Up") }
+        }
+        error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(text = it, color = MaterialTheme.colorScheme.error)
+        }
+    }
 }

--- a/app/src/main/java/com/arova/arova/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/signup/SignUpViewModel.kt
@@ -1,8 +1,52 @@
 package com.arova.arova.ui.signup
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.arova.domain.SignUpUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
-class SignUpViewModel @Inject constructor() : ViewModel()
+class SignUpViewModel @Inject constructor(
+    private val signUpUseCase: SignUpUseCase
+) : ViewModel() {
+
+    val name = MutableStateFlow("")
+    val email = MutableStateFlow("")
+    val password = MutableStateFlow("")
+    val confirmPassword = MutableStateFlow("")
+
+    val isLoading = MutableStateFlow(false)
+    val errorMessage = MutableStateFlow<String?>(null)
+
+    private val _signUpSuccess = MutableSharedFlow<Unit>()
+    val signUpSuccess: SharedFlow<Unit> = _signUpSuccess
+
+    fun onSignUpClicked() {
+        if (name.value.isBlank() || email.value.isBlank() ||
+            password.value.isBlank() || confirmPassword.value.isBlank()
+        ) {
+            errorMessage.value = "All fields are required"
+            return
+        }
+        if (password.value != confirmPassword.value) {
+            errorMessage.value = "Passwords do not match"
+            return
+        }
+        viewModelScope.launch {
+            isLoading.value = true
+            val result = signUpUseCase(name.value, email.value, password.value)
+            isLoading.value = false
+            result.onSuccess {
+                _signUpSuccess.emit(Unit)
+            }.onFailure {
+                errorMessage.value = it.message
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/arova/arova/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/arova/arova/ui/welcome/WelcomeScreen.kt
@@ -1,10 +1,33 @@
 package com.arova.arova.ui.welcome
 
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
-fun WelcomeScreen(viewModel: WelcomeViewModel = hiltViewModel()) {
-    Text(text = "Welcome")
+fun WelcomeScreen(
+    viewModel: WelcomeViewModel = hiltViewModel(),
+    onSignUp: () -> Unit = {}
+) {
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        viewModel.navigateToSignUp.collect { onSignUp() }
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Welcome to Arova")
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = { viewModel.onSignUpClicked() }) { Text("Sign Up") }
+    }
 }

--- a/app/src/main/java/com/arova/arova/ui/welcome/WelcomeViewModel.kt
+++ b/app/src/main/java/com/arova/arova/ui/welcome/WelcomeViewModel.kt
@@ -1,8 +1,20 @@
 package com.arova.arova.ui.welcome
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
-class WelcomeViewModel @Inject constructor() : ViewModel()
+class WelcomeViewModel @Inject constructor() : ViewModel() {
+
+    private val _navigateToSignUp = MutableSharedFlow<Unit>()
+    val navigateToSignUp: SharedFlow<Unit> = _navigateToSignUp
+
+    fun onSignUpClicked() {
+        viewModelScope.launch { _navigateToSignUp.emit(Unit) }
+    }
+}

--- a/data/src/main/java/com/arova/data/InMemoryUserRepository.kt
+++ b/data/src/main/java/com/arova/data/InMemoryUserRepository.kt
@@ -1,0 +1,18 @@
+package com.arova.data
+
+import com.arova.domain.UserRepository
+import javax.inject.Inject
+
+class InMemoryUserRepository @Inject constructor() : UserRepository {
+    private data class Account(val name: String, val email: String, val password: String)
+    private val accounts = mutableListOf<Account>()
+
+    override suspend fun signUp(name: String, email: String, password: String): Result<Unit> {
+        return if (accounts.any { it.email == email }) {
+            Result.failure(Exception("Email already registered"))
+        } else {
+            accounts.add(Account(name, email, password))
+            Result.success(Unit)
+        }
+    }
+}

--- a/data/src/main/java/com/arova/data/LocalMealDao.kt
+++ b/data/src/main/java/com/arova/data/LocalMealDao.kt
@@ -4,4 +4,6 @@ import com.arova.domain.MealEntry
 
 interface LocalMealDao {
     suspend fun insertMeal(meal: MealEntry)
+
+    suspend fun getMealsForDate(start: Long, end: Long): List<MealEntryWithItems>
 }

--- a/data/src/main/java/com/arova/data/LocalMealDao.kt
+++ b/data/src/main/java/com/arova/data/LocalMealDao.kt
@@ -1,5 +1,6 @@
 package com.arova.data
 
+import com.arova.data.local.MealEntryWithItems
 import com.arova.domain.MealEntry
 
 interface LocalMealDao {

--- a/data/src/main/java/com/arova/data/MealRepositoryImpl.kt
+++ b/data/src/main/java/com/arova/data/MealRepositoryImpl.kt
@@ -8,4 +8,26 @@ class MealRepositoryImpl @Inject constructor(private val localMealDao: LocalMeal
     override suspend fun saveMeal(meal: MealEntry) {
         localMealDao.insertMeal(meal)
     }
+
+    override suspend fun getMealsForDate(date: java.time.LocalDate): List<MealEntry> {
+        val start = date.atStartOfDay().toEpochSecond(java.time.ZoneOffset.UTC)
+        val end = date.plusDays(1).atStartOfDay().toEpochSecond(java.time.ZoneOffset.UTC) - 1
+        return localMealDao.getMealsForDate(start, end).map { entry ->
+            MealEntry(
+                items = entry.items.map {
+                    com.arova.domain.FoodItem(
+                        name = it.name,
+                        quantity = it.quantity,
+                        unit = it.unit,
+                        calories = it.calories,
+                        protein = it.protein,
+                        carbs = it.carbs,
+                        fat = it.fat
+                    )
+                },
+                date = java.time.LocalDateTime.ofEpochSecond(entry.meal.date, 0, java.time.ZoneOffset.UTC),
+                mealType = entry.meal.mealType
+            )
+        }
+    }
 }

--- a/data/src/main/java/com/arova/data/di/DataModule.kt
+++ b/data/src/main/java/com/arova/data/di/DataModule.kt
@@ -12,7 +12,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.create
-import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import okhttp3.MediaType.Companion.toMediaType
 import com.arova.domain.*
 import dagger.Binds

--- a/data/src/main/java/com/arova/data/di/DataModule.kt
+++ b/data/src/main/java/com/arova/data/di/DataModule.kt
@@ -35,6 +35,9 @@ interface DataModule {
     @Binds
     fun bindUserProfileRepository(impl: UserProfileRepositoryImpl): UserProfileRepository
 
+    @Binds
+    fun bindUserRepository(impl: InMemoryUserRepository): UserRepository
+
     companion object {
         @Provides
         @Singleton

--- a/data/src/main/java/com/arova/data/local/MealDao.kt
+++ b/data/src/main/java/com/arova/data/local/MealDao.kt
@@ -11,4 +11,8 @@ interface MealDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertItems(items: List<FoodItemEntity>)
+
+    @androidx.room.Transaction
+    @androidx.room.Query("SELECT * FROM meal_entries WHERE date BETWEEN :start AND :end")
+    suspend fun getMealsForDate(start: Long, end: Long): List<MealEntryWithItems>
 }

--- a/data/src/main/java/com/arova/data/local/MealEntryWithItems.kt
+++ b/data/src/main/java/com/arova/data/local/MealEntryWithItems.kt
@@ -1,0 +1,10 @@
+package com.arova.data.local
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class MealEntryWithItems(
+    @Embedded val meal: MealEntryEntity,
+    @Relation(parentColumn = "id", entityColumn = "mealId")
+    val items: List<FoodItemEntity>
+)

--- a/data/src/main/java/com/arova/data/local/RoomLocalMealDao.kt
+++ b/data/src/main/java/com/arova/data/local/RoomLocalMealDao.kt
@@ -26,4 +26,8 @@ class RoomLocalMealDao(private val dao: MealDao) : LocalMealDao {
         }
         dao.insertItems(items)
     }
+
+    override suspend fun getMealsForDate(start: Long, end: Long): List<MealEntryWithItems> {
+        return dao.getMealsForDate(start, end)
+    }
 }

--- a/domain/src/main/java/com/arova/domain/DailySummary.kt
+++ b/domain/src/main/java/com/arova/domain/DailySummary.kt
@@ -1,0 +1,8 @@
+package com.arova.domain
+
+data class DailySummary(
+    val totalCalories: Int,
+    val protein: Double,
+    val carbs: Double,
+    val fat: Double
+)

--- a/domain/src/main/java/com/arova/domain/GetDailySummaryUseCase.kt
+++ b/domain/src/main/java/com/arova/domain/GetDailySummaryUseCase.kt
@@ -1,0 +1,15 @@
+package com.arova.domain
+
+import java.time.LocalDate
+import javax.inject.Inject
+
+class GetDailySummaryUseCase @Inject constructor(private val repository: MealRepository) {
+    suspend operator fun invoke(date: LocalDate): DailySummary {
+        val meals = repository.getMealsForDate(date)
+        val calories = meals.sumOf { meal -> meal.items.sumOf { it.calories } }
+        val protein = meals.sumOf { meal -> meal.items.sumOf { it.protein } }
+        val carbs = meals.sumOf { meal -> meal.items.sumOf { it.carbs } }
+        val fat = meals.sumOf { meal -> meal.items.sumOf { it.fat } }
+        return DailySummary(calories, protein, carbs, fat)
+    }
+}

--- a/domain/src/main/java/com/arova/domain/MealRepository.kt
+++ b/domain/src/main/java/com/arova/domain/MealRepository.kt
@@ -2,4 +2,6 @@ package com.arova.domain
 
 interface MealRepository {
     suspend fun saveMeal(meal: MealEntry)
+
+    suspend fun getMealsForDate(date: java.time.LocalDate): List<MealEntry>
 }

--- a/domain/src/main/java/com/arova/domain/SignUpUseCase.kt
+++ b/domain/src/main/java/com/arova/domain/SignUpUseCase.kt
@@ -1,0 +1,9 @@
+package com.arova.domain
+
+import javax.inject.Inject
+
+class SignUpUseCase @Inject constructor(private val repository: UserRepository) {
+    suspend operator fun invoke(name: String, email: String, password: String): Result<Unit> {
+        return repository.signUp(name, email, password)
+    }
+}

--- a/domain/src/main/java/com/arova/domain/User.kt
+++ b/domain/src/main/java/com/arova/domain/User.kt
@@ -1,0 +1,6 @@
+package com.arova.domain
+
+data class User(
+    val name: String,
+    val email: String
+)

--- a/domain/src/main/java/com/arova/domain/UserRepository.kt
+++ b/domain/src/main/java/com/arova/domain/UserRepository.kt
@@ -1,0 +1,5 @@
+package com.arova.domain
+
+interface UserRepository {
+    suspend fun signUp(name: String, email: String, password: String): Result<Unit>
+}


### PR DESCRIPTION
## Summary
- implement SignUpUseCase and in-memory UserRepository
- implement DailySummary logic and retrieval of meals
- flesh out Compose screens and view models for onboarding, dashboard and food logging
- wire navigation between screens

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872755203c0832ba78b2125d971df48